### PR TITLE
Replace `start.sh` and bump to 2.14.8 (#22)

### DIFF
--- a/2.14/Dockerfile
+++ b/2.14/Dockerfile
@@ -10,6 +10,10 @@ RUN /build/scripts/getDeps.sh && \
     /build/scripts/make.sh && \
     /build/scripts/clean.sh
 
+# Called on first run of docker
+ADD start.sh /start.sh
+RUN chmod 0755 /start.sh
+
 # A few tunable variables for QGIS
 ENV QGIS_DEBUG 5
 ENV QGIS_LOG_FILE /proc/self/fd/1

--- a/2.14/build.sh
+++ b/2.14/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker build -t kartoza/qgis-desktop:2.14.6 .
+docker build -t kartoza/qgis-desktop:2.14.8 .
 docker build -t kartoza/qgis-desktop:LTR .
 sudo cp run-qgis-2.14ltr-in-docker.sh /usr/local/bin
 sudo cp QGIS-2.14LTR.Docker.desktop /usr/share/applications/

--- a/2.14/build/clean.sh
+++ b/2.14/build/clean.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-apt-get remove -y --purge krb5-multidev build-essential bison cmake make cpp cpp-4.9 gfortran-5 g++ g++-4.9 gcc gcc-4.9 \
+apt-get remove -y --purge krb5-multidev build-essential bison cmake make cpp cpp-5 gfortran-5 g++ gcc gcc-5 \
     flex libclang1-3.5 git qt4-qmake rsync cmake-data g++-5 git-man liberror-perl qt4-linguist-tools libqt4-dev-bin
 dpkg --purge `dpkg -l "*-dev" | sed -ne 's/ii  \(.*-dev\(:amd64\)\?\) .*/\1/p'` || true
 

--- a/2.14/build/clean.sh
+++ b/2.14/build/clean.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-apt-get remove -y --purge krb5-multidev build-essential bison cmake make cpp cpp-4.9 g++ g++-4.9 gcc gcc-4.9 \
+apt-get remove -y --purge krb5-multidev build-essential bison cmake make cpp cpp-4.9 gfortran-5 g++ g++-4.9 gcc gcc-4.9 \
     flex libclang1-3.5 git qt4-qmake rsync cmake-data g++-5 git-man liberror-perl qt4-linguist-tools libqt4-dev-bin
 dpkg --purge `dpkg -l "*-dev" | sed -ne 's/ii  \(.*-dev\(:amd64\)\?\) .*/\1/p'` || true
 

--- a/2.14/build/getCode.sh
+++ b/2.14/build/getCode.sh
@@ -2,6 +2,6 @@
 set -e
 
 cd /build
-git clone --depth 1 -b final-2_14_7 git://github.com/qgis/QGIS.git
+git clone --depth 1 -b final-2_14_8 git://github.com/qgis/QGIS.git
 cd QGIS
-#git checkout final-2_14_7
+#git checkout final-2_14_8

--- a/2.14/build/make.sh
+++ b/2.14/build/make.sh
@@ -10,15 +10,15 @@ cmake /build/QGIS \
     -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython2.7.so \
     -DQSCINTILLA_INCLUDE_DIR=/usr/include/qt4 \
     -DQWT_LIBRARY=/usr/lib/libqwt.so \
-    -DWITH_DESKTOP=OFF \
-    -DWITH_SERVER=ON \
+    -DWITH_DESKTOP=ON \
+    -DWITH_SERVER=OFF \
     -DBUILD_TESTING=OFF \
     -DWITH_INTERNAL_QWTPOLAR=ON
 
 make install -j8
 ldconfig
 
-strip /usr/bin/qgis_mapserv.fcgi
+#strip /usr/bin/qgis_mapserv.fcgi
 strip `find /usr/lib/ -name "libqgis*" -type f`
 strip `find  /usr/share/qgis/ -name "*.so" -type f`
 


### PR DESCRIPTION
Re #22. I just noticed (after building) that the build script specifies server=on and desktop=off. Is this a mistake, or have you recently changed strategy?

~~Edit: odd, I built this image, but the container is now complaining about `/usr/bin/qgis` not existing. I can't find the executable any where in the container.~~